### PR TITLE
Get attribute instead of dictionary item

### DIFF
--- a/sentry_auth_thalia/provider.py
+++ b/sentry_auth_thalia/provider.py
@@ -56,7 +56,7 @@ class ThaliaAuthProvider(Provider):
     def refresh_identity(self, auth_identity):
         client = ThaliaClient()
         try:
-            user_data = client.get_user(auth_identity['data']['auth_token'])
+            user_data = client.get_user(auth_identity.data['auth_token'])
 
             auth_identity.user.update(
                 name=u'{} {}'.format(


### PR DESCRIPTION
As we now can see in Sentry, [`refresh_identity` is throwing errors](https://sentry.thalia.nu/thalia/internal/issues/7/).

Looking at the [github auth plugin](https://github.com/getsentry/sentry-auth-github/blob/43f6b270b3fac32326518a78be77562ebe5abacf/sentry_auth_github/provider.py#L82) and the source code of Sentry, it seems `data` is an attribute.

I did not find any reference to `auth_token`, but I did find references to `access_token`. Maybe that should be changed too?  