### PR TITLE
Remove redundant installation of Sentry package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     packages=['sentry_auth_thalia'],
     zip_safe=False,
     install_requires=[
-        'sentry>=7.0.0',
         'requests>=2.18.0'
         ],
     tests_require=['flake8'],


### PR DESCRIPTION
Closes #6 

The `sentry` package already gets installed in the original Docker image. 

Removing this line insures that the original package is used and no package is upgraded (with potential dependency errors).